### PR TITLE
BUGFIX: m_data and m_match properties should return a python bytes instead of str

### DIFF
--- a/src/rule_message.cpp
+++ b/src/rule_message.cpp
@@ -35,7 +35,14 @@ void init_rule_message(py::module &m)
 
         .def_readwrite("m_id", &RuleMessage::m_id)
         .def_readwrite("m_isDisruptive", &RuleMessage::m_isDisruptive)
-        .def_readwrite("m_match", &RuleMessage::m_match)
+        
+        //.def_readwrite("m_match", &RuleMessage::m_match)
+        .def_property("m_match", [](const RuleMessage& rm) {
+          return py::bytes(rm.m_match);
+        }, [](RuleMessage& rm, const std::string m_match) {
+          rm.m_match = m_match;
+        }, py::return_value_policy::copy)
+
         .def_readwrite("m_maturity", &RuleMessage::m_maturity)
         .def_readwrite("m_message", &RuleMessage::m_message)
         .def_readwrite("m_noAuditLog", &RuleMessage::m_noAuditLog)

--- a/src/rule_message.cpp
+++ b/src/rule_message.cpp
@@ -25,7 +25,14 @@ void init_rule_message(py::module &m)
         .def_static("_errorLogTail", (std::string (*) (const RuleMessage *)) &RuleMessage::_errorLogTail)
         .def_readwrite("m_accuracy", &RuleMessage::m_accuracy)
         .def_readwrite("m_clientIpAddress", &RuleMessage::m_clientIpAddress)
-        .def_readwrite("m_data", &RuleMessage::m_data)
+
+        // .def_readwrite("m_data", &RuleMessage::m_data)
+        .def_property("m_data", [](const RuleMessage& rm) {
+          return py::bytes(rm.m_data);
+        }, [](RuleMessage& rm, const std::string m_data) {
+          rm.m_data = m_data;
+        }, py::return_value_policy::copy)
+
         .def_readwrite("m_id", &RuleMessage::m_id)
         .def_readwrite("m_isDisruptive", &RuleMessage::m_isDisruptive)
         .def_readwrite("m_match", &RuleMessage::m_match)


### PR DESCRIPTION
When a C++ function returns a `std::string` or `char*` to a Python caller,
pybind11 will assume that the string is valid UTF-8 and will decode it to a native Python str.

In some cases the `m_data` and `m_match` does not contains a valid UTF-8 encoding
and pybind11 will raise a `UnicodeDecodeError`.
see: [pybind11 doc](https://pybind11.readthedocs.io/en/stable/advanced/cast/strings.html)

Since they contains an HTTP body data, `m_data` and `m_match` should return a python bytes.